### PR TITLE
config.toml: update Google Analytics ID for GA4 migration

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,9 +1,9 @@
-base_url = "//docs.worldwidetelescope.org/tour-authoring-guide/1/"
+base_url = "https://docs.worldwidetelescope.org/tour-authoring-guide/1/"
 title = "WWT Tour Authoring Guide"
 description = "Creating AAS WorldWide Telescope tours."
 theme = "wwtguide"
 highlight_code = true
 
 [extra]
-github_base = "//github.com/WorldWideTelescope/worldwide-telescope-tour-authoring-guide"
-google_analytics_id = "UA-107473046-3"
+github_base = "https://github.com/WorldWideTelescope/worldwide-telescope-tour-authoring-guide"
+google_analytics_id = "G-D1J49XX0CV"


### PR DESCRIPTION
More Google Analytics 4 migration. For a comprehensive set of all PR's, see:

https://github.com/WorldWideTelescope/wwt-website/pull/305